### PR TITLE
Update hypernova.rb path on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ module ApplicationHelper
 end
 ```
 
-5. At `initializer/hypernova.rb`
+5. At `config/initializers/hypernova.rb`
 ```
 require 'hypernova'
 require 'hypernova/plugins/development_mode_plugin'


### PR DESCRIPTION
I'm trying to manually set up vue on rails ssr and this path threw me off:

`config/initializers/hypernova.rb`